### PR TITLE
Add support for AlternateNamesV2

### DIFF
--- a/NGeoNames/Composers/AlternateNameV2Composer.cs
+++ b/NGeoNames/Composers/AlternateNameV2Composer.cs
@@ -1,0 +1,27 @@
+﻿using NGeoNames.Entities;
+
+namespace NGeoNames.Composers
+{
+    /// <summary>
+    /// Provides methods for composing a string representing an <see cref="AlternateName"/>.
+    /// </summary>
+    public class AlternateNameV2Composer : BaseComposer<AlternateNameV2>
+    {
+        /// <summary>
+        /// Composes the specified <see cref="AlternateNameV2"/> into a string.
+        /// </summary>
+        /// <param name="value">The <see cref="AlternateNameV2"/> to be composed into a string.</param>
+        /// <returns>A string representing the specified <see cref="AlternateNameV2"/>.</returns>
+        public override string Compose(AlternateNameV2 value)
+        {
+            return string.Join(FieldSeparator.ToString(), value.Id, value.GeoNameId, string.IsNullOrEmpty(value.Type) ? value.ISOLanguage : value.Type,
+                value.Name, Bool2String(value.IsPreferredName), Bool2String(value.IsShortName), Bool2String(value.IsColloquial), Bool2String(value.IsHistoric),
+                value.From, value.To);
+        }
+
+        private static string Bool2String(bool value)
+        {
+            return value ? "1" : string.Empty;
+        }
+    }
+}

--- a/NGeoNames/Entities/AlternateNameV2.cs
+++ b/NGeoNames/Entities/AlternateNameV2.cs
@@ -1,13 +1,15 @@
-﻿namespace NGeoNames.Entities
+namespace NGeoNames.Entities
 {
     /// <summary>
-    /// Represents an alternate name for a specific <see cref="GeoName"/> or <see cref="ExtendedGeoName"/>.
+    /// Represents an alternate name for a specific <see cref="GeoName"/> or <see cref="ExtendedGeoName"/>. This entity
+    /// represents a newer version of the <see cref="AlternateName"/> type, with new From and To properties that describe
+    /// the historical usage of the name.
     /// </summary>
     /// <remarks>
     /// The property <see cref="ExtendedGeoName.AlternateNames"/> of the <see cref="ExtendedGeoName"/> object is a short
-    /// version of the <see cref="AlternateName"/> data without links and postal codes but with ASCUU transliterations.
+    /// version of the <see cref="AlternateNameV2"/> data without links and postal codes but with ASCUU transliterations.
     /// </remarks>
-    public class AlternateName
+    public class AlternateNameV2
     {
         /// <summary>
         /// Gets/sets the Id of the <see cref="AlternateName"/>.
@@ -56,5 +58,15 @@
         /// Gets/sets whether this <see cref="AlternateName"/> is historic and was used in the past
         /// </summary>
         public bool IsHistoric { get; set; }
+
+        /// <summary>
+        /// Gets/sets the start date for the historical period during which this name was used
+        /// </summary>
+        public string From { get; set; }
+
+        /// <summary>
+        /// Gets/sets the end date for the historical period during which this name was used
+        /// </summary>
+        public string To { get; set; }
     }
 }

--- a/NGeoNames/GeoFileReader.cs
+++ b/NGeoNames/GeoFileReader.cs
@@ -270,6 +270,34 @@ namespace NGeoNames
         }
 
         /// <summary>
+        /// Reads <see cref="AlternateNameV2"/> records from the specified file, using the default <see cref="AlternateNameParserV2"/>.
+        /// </summary>
+        /// <param name="filename">The name/path of the file.</param>
+        /// <returns>Returns an IEnumerable of <see cref="AlternateNameV2"/> representing the records read/parsed.</returns>
+        /// <remarks>
+        /// This static method is a convenience-method; see the ReadRecords{T} overloaded instance-methods for
+        /// more control over how the file is read.
+        /// </remarks>
+        public static IEnumerable<AlternateNameV2> ReadAlternateNamesV2(string filename)
+        {
+            return new GeoFileReader().ReadRecords(filename, new AlternateNameParserV2());
+        }
+
+        /// <summary>
+        /// Reads <see cref="AlternateNameV2"/> records from the <see cref="Stream"/>, using the default <see cref="AlternateNameParserV2"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to read/parse.</param>
+        /// <returns>Returns an IEnumerable of <see cref="AlternateNameV2"/> representing the records read/parsed.</returns>
+        /// <remarks>
+        /// This static method is a convenience-method; see the ReadRecords{T} overloaded instance-methods for
+        /// more control over how the stream is read.
+        /// </remarks>
+        public static IEnumerable<AlternateNameV2> ReadAlternateNamesV2(Stream stream)
+        {
+            return new GeoFileReader().ReadRecords(stream, new AlternateNameParserV2());
+        }
+
+        /// <summary>
         /// Reads <see cref="Continent"/> records from the built-in data, using the default <see cref="ContinentParser"/>.
         /// </summary>
         /// <returns>Returns an IEnumerable of <see cref="Continent"/> representing the records read/parsed.</returns>

--- a/NGeoNames/GeoFileWriter.cs
+++ b/NGeoNames/GeoFileWriter.cs
@@ -172,6 +172,34 @@ namespace NGeoNames
         }
 
         /// <summary>
+        /// Writes <see cref="AlternateNameV2"/> records to the specified file, using the default <see cref="AlternateNameV2Composer"/>.
+        /// </summary>
+        /// <param name="filename">The name/path of the file.</param>
+        /// <param name="values">The values to write to the file.</param>
+        /// <remarks>
+        /// This static method is a convenience-method; see the WriteRecords{T} overloaded instance-methods for
+        /// more control over how the file is written.
+        /// </remarks>
+        public static void WriteAlternateNamesV2(string filename, IEnumerable<AlternateNameV2> values)
+        {
+            new GeoFileWriter().WriteRecords(filename, values, new AlternateNameV2Composer());
+        }
+
+        /// <summary>
+        /// Writes <see cref="AlternateNameV2"/> records to the <see cref="Stream"/>, using the default <see cref="AlternateNameV2Composer"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write to.</param>
+        /// <param name="values">The values to write to the stream.</param>
+        /// <remarks>
+        /// This static method is a convenience-method; see the WriteRecords{T} overloaded instance-methods for
+        /// more control over how the stream is written.
+        /// </remarks>
+        public static void WriteAlternateNamesV2(Stream stream, IEnumerable<AlternateNameV2> values)
+        {
+            new GeoFileWriter().WriteRecords(stream, values, new AlternateNameV2Composer());
+        }
+
+        /// <summary>
         /// Writes <see cref="Continent"/> records to the specified file, using the default <see cref="ContinentComposer"/>.
         /// </summary>
         /// <param name="filename">The name/path of the file.</param>

--- a/NGeoNames/Parsers/AlternateNameParserV2.cs
+++ b/NGeoNames/Parsers/AlternateNameParserV2.cs
@@ -1,0 +1,59 @@
+using NGeoNames.Entities;
+
+namespace NGeoNames.Parsers
+{
+    public class AlternateNameParserV2 : BaseParser<AlternateNameV2>
+    {
+        /// <summary>
+        /// Gets wether the file/stream has (or is expected to have) comments (lines starting with "#").
+        /// </summary>
+        public override bool HasComments
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        /// Gets the number of lines to skip when parsing the file/stream (e.g. 'headers' etc.).
+        /// </summary>
+        public override int SkipLines
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        /// Gets the number of fields the file/stream is expected to have; anything else will cause a <see cref="ParserException"/>.
+        /// </summary>
+        public override int ExpectedNumberOfFields
+        {
+            get { return 10; }
+        }
+
+        /// <summary>
+        /// Parses the specified data into an <see cref="AlternateNameV2"/> object.
+        /// </summary>
+        /// <param name="fields">The fields/data representing an <see cref="AlternateNameV2"/> to parse.</param>
+        /// <returns>Returns a new <see cref="AlternateNameV2"/> object.</returns>
+        public override AlternateNameV2 Parse(string[] fields)
+        {
+            return new AlternateNameV2
+            {
+                Id = StringToInt(fields[0]),
+                GeoNameId = StringToInt(fields[1]),
+                ISOLanguage = fields[2].Length <= 3 ? fields[2] : null,
+                Type = fields[2].Length <= 3 ? null : fields[2],
+                Name = fields[3],
+                IsPreferredName = BoolToString(fields[4]),
+                IsShortName = BoolToString(fields[5]),
+                IsColloquial = BoolToString(fields[6]),
+                IsHistoric = BoolToString(fields[7]),
+                From = fields[8],
+                To = fields[9]
+            };
+        }
+
+        private static bool BoolToString(string value)
+        {
+            return value.Equals("1");
+        }
+    }
+}

--- a/NGeoNamesTests/ComposerTests.cs
+++ b/NGeoNamesTests/ComposerTests.cs
@@ -42,6 +42,17 @@ namespace NGeoNamesTests
         }
 
         [TestMethod]
+        public void AlternateNamesComposerV2_ComposesFileCorrectly()
+        {
+            var src = @"testdata\test_alternateNamesV2.txt";
+            var dst = @"testdata\test_alternateNamesV2.out.txt";
+
+            GeoFileWriter.WriteAlternateNamesV2(dst, GeoFileReader.ReadAlternateNamesV2(src));
+
+            FileUtil.EnsureFilesAreFunctionallyEqual(src, dst, 10, 0, new[] { '\t' }, Encoding.UTF8, false);
+        }
+
+        [TestMethod]
         public void ContinentComposer_ComposesFileCorrectly()
         {
             var src = @"testdata\test_continentCodes.txt";

--- a/NGeoNamesTests/NGeoNamesTests.csproj
+++ b/NGeoNamesTests/NGeoNamesTests.csproj
@@ -79,6 +79,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="CustomComposer.cs" />
+    <Content Include="Testdata\test_alternateNamesV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Testdata\test_geonames_ext.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/NGeoNamesTests/ParserTests.cs
+++ b/NGeoNamesTests/ParserTests.cs
@@ -151,6 +151,103 @@ namespace NGeoNamesTests
         }
 
         [TestMethod]
+        public void AlternateNamesParserV2_ParsesFileCorrectly()
+        {
+            var target = GeoFileReader.ReadAlternateNamesV2(@"testdata\test_alternateNamesV2.txt").ToArray();
+            Assert.AreEqual(19, target.Length);
+
+            Assert.AreEqual("رودخانه زاکلی", target[0].Name);
+            Assert.AreEqual("fa", target[0].ISOLanguage);       //Ensure we have an ISO code
+            Assert.IsNull(target[0].Type);                      //When ISO code is specified, type should be null
+            Assert.AreEqual(false, target[0].IsPreferredName);  //All these...
+            Assert.AreEqual(false, target[0].IsColloquial);     //...bits should...
+            Assert.AreEqual(false, target[0].IsShortName);      //...be set...
+            Assert.AreEqual(false, target[0].IsHistoric);       //...to false
+
+            Assert.AreEqual("http://en.wikipedia.org/wiki/Takht-e_Qeysar", target[1].Name);
+            Assert.IsNull(target[1].ISOLanguage);           //Should be null when a type is specified (e.g. length of ISO code field > 3)
+            Assert.AreEqual("link", target[1].Type);        //Ensure we have a type
+
+            Assert.AreEqual("Нагольная", target[2].Name);
+
+            Assert.AreEqual("บ้านน้ำฉ่า", target[3].Name);
+            Assert.AreEqual("th", target[3].ISOLanguage);
+
+            Assert.AreEqual("글렌로시스", target[4].Name);
+            Assert.AreEqual("ko", target[4].ISOLanguage);
+
+            //Postal code
+            Assert.AreEqual("TW13", target[5].Name);
+            Assert.AreEqual("post", target[5].Type);
+
+            //IATA - International Air Transport Association; airport code
+            Assert.AreEqual("FAB", target[6].Name);
+            Assert.AreEqual("iata", target[6].Type);
+
+            //ICAO - International Civil Aviation Organization airport code
+            Assert.AreEqual("LSGG", target[7].Name);
+            Assert.AreEqual("icao", target[7].Type);
+
+            //ICAO - International Civil Aviation Organization airport code
+            Assert.AreEqual("GSN", target[8].Name);
+            Assert.AreEqual("faac", target[8].Type);
+
+            Assert.AreEqual("Saipan International Airport", target[9].Name);
+            Assert.AreEqual("", target[9].ISOLanguage); //No language,...
+            Assert.IsNull(target[9].Type);              //...no type
+
+            //Link
+            Assert.AreEqual("http://en.wikipedia.org/wiki/Saipan_International_Airport", target[10].Name);
+            Assert.AreEqual("link", target[10].Type);
+
+            //fr_1793 - French Revolution name
+            Assert.AreEqual("Ile-de-la-Liberté", target[11].Name);
+            Assert.AreEqual("fr_1793", target[11].Type);
+
+            Assert.AreEqual("ཞིང་རི", target[12].Name);
+            Assert.AreEqual("bo", target[12].ISOLanguage);
+
+            //Abbreviation
+            Assert.AreEqual("TRTO", target[13].Name);
+            Assert.AreEqual("abbr", target[13].Type);
+
+            //Check flags/bits
+            Assert.AreEqual("The Jekyll & Hyde Pub", target[14].Name);
+            Assert.AreEqual(true, target[14].IsPreferredName);
+            Assert.AreEqual(false, target[14].IsColloquial);
+            Assert.AreEqual(true, target[14].IsShortName);
+            Assert.AreEqual(false, target[14].IsHistoric);
+
+            Assert.AreEqual("Torre Fiumicelli", target[15].Name);
+            Assert.AreEqual(false, target[15].IsPreferredName);
+            Assert.AreEqual(true, target[15].IsColloquial);
+            Assert.AreEqual(false, target[15].IsShortName);
+            Assert.AreEqual(false, target[15].IsHistoric);
+
+            Assert.AreEqual("Abbaye Saint-Antoine-des-Champs", target[16].Name);
+            Assert.AreEqual(false, target[16].IsPreferredName);
+            Assert.AreEqual(false, target[16].IsColloquial);
+            Assert.AreEqual(false, target[16].IsShortName);
+            Assert.AreEqual(true, target[16].IsHistoric);
+
+            //Check from/to
+            Assert.AreEqual("Volgograd", target[17].Name);
+            Assert.AreEqual(true, target[17].IsPreferredName);
+            Assert.AreEqual(false, target[17].IsColloquial);
+            Assert.AreEqual(false, target[17].IsShortName);
+            Assert.AreEqual(false, target[17].IsHistoric);
+            Assert.AreEqual("1961", target[17].From);
+
+            Assert.AreEqual("Tsaritsyn", target[18].Name);
+            Assert.AreEqual(false, target[18].IsPreferredName);
+            Assert.AreEqual(false, target[18].IsColloquial);
+            Assert.AreEqual(false, target[18].IsShortName);
+            Assert.AreEqual(true, target[18].IsHistoric);
+            Assert.AreEqual("1589", target[18].From);
+            Assert.AreEqual("1925", target[18].To);
+        }
+
+        [TestMethod]
         public void CountryInfoParser_ParsesFileCorrectly()
         {
             var target = GeoFileReader.ReadCountryInfo(@"testdata\test_countryInfo.txt").ToArray();
@@ -871,6 +968,13 @@ namespace NGeoNamesTests
         {
             using (var s = File.OpenRead(@"testdata\test_alternateNames.txt"))
                 GeoFileReader.ReadAlternateNames(s).Count();
+        }
+
+        [TestMethod]
+        public void FileReader_AlternateNamesV2_StreamOverload()
+        {
+            using (var s = File.OpenRead(@"testdata\test_alternateNamesV2.txt"))
+                GeoFileReader.ReadAlternateNamesV2(s).Count();
         }
 
         [TestMethod]

--- a/NGeoNamesTests/Testdata/test_alternateNamesV2.txt
+++ b/NGeoNamesTests/Testdata/test_alternateNamesV2.txt
@@ -1,0 +1,19 @@
+2488123	4	fa	رودخانه زاکلی						
+8078498	12	link	http://en.wikipedia.org/wiki/Takht-e_Qeysar						
+3810073	523619		Нагольная						
+9189113	1616332	th	บ้านน้ำฉ่า						
+8196652	2648438	ko	글렌로시스						
+7636553	2649571	post	TW13						
+7481730	2649672	iata	FAB						
+1886364	2660644	icao	LSGG						
+5906078	4041549	faac	GSN						
+5906077	4041549		Saipan International Airport						
+2989172	4041549	link	http://en.wikipedia.org/wiki/Saipan_International_Airport						
+2259865	6559563	fr_1793	Ile-de-la-Liberté						
+2197207	6559568	bo	ཞིང་རི						
+8488823	6615458	abbr	TRTO						
+2256760	6615468	en	The Jekyll & Hyde Pub	1	1				
+2299521	6621102	it	Torre Fiumicelli			1			
+8066371	6639742	fr	Abbaye Saint-Antoine-des-Champs				1		
+9528154	472757	en	Volgograd	1				1961	
+13634199	472757	en	Tsaritsyn				1	1589	1925


### PR DESCRIPTION
This PR adds support for the AlternateNamesV2 file type (see #5). It really just adds two new fields to the AlternateName entity that existed already - To and From, denoting the start and end of the historical period during which a particular alternate name was in usage. These fields have a type of String - I wasn't sure if this was the most appropriate type (versus DateTime, for example) but there seem to be a good few edge cases in the data itself (see, for example, alternate name ID 13653649). Tests and some new test data are included.

