### PR TITLE
Updated README file - fixed distance unit in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ var results = reversegeocoder.RadialSearch(amsterdam, 250);
 foreach (var r in results) {
     Console.WriteLine(
         string.Format(
-            CultureInfo.InvariantCulture, "{0}, {1} {2} ({3:F4}m)", 
-            r.Latitude, r.Longitude, r.Name, r.DistanceTo(amsterdam)
+            CultureInfo.InvariantCulture, "{0}, {1} {2} ({3:F4}Km)", 
+            r.Latitude, r.Longitude, r.Name, r.DistanceTo(amsterdam) / 1000d
         )
     );
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var results = reversegeocoder.RadialSearch(amsterdam, 250);
 foreach (var r in results) {
     Console.WriteLine(
         string.Format(
-            CultureInfo.InvariantCulture, "{0}, {1} {2} ({3:F4}Km)", 
+            CultureInfo.InvariantCulture, "{0}, {1} {2} ({3:F4}m)", 
             r.Latitude, r.Longitude, r.Name, r.DistanceTo(amsterdam)
         )
     );


### PR DESCRIPTION
First of all: thanks for creating this project! Looks very interesting.

I have tested the example provided in the README file, and the output of `r.DistanceTo(amsterdam)` is in meters instead of kilometers.

If you can confirm it, please kindly accept the PR so the documentation is fixed.

Best,
Miguel
